### PR TITLE
feat: Implement dark mode

### DIFF
--- a/src/app/(app)/chat-layout.tsx
+++ b/src/app/(app)/chat-layout.tsx
@@ -4,6 +4,7 @@ import type * as React from "react";
 import { Plus } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
+import { ThemeToggle } from "@/components/ui/theme-toggle";
 
 import {
   Sidebar,
@@ -78,8 +79,8 @@ export default function ChatLayout({
                       variant={"ghost"}
                       asChild
                       className={clsx(
-                        "w-full justify-start p-2 h-12 hover:bg-stone-200 active:bg-stone-200",
-                        currentChatId === chat.id ? "bg-stone-200" : ""
+                        "w-full justify-start p-2 h-12 hover:bg-sidebar-accent active:bg-sidebar-accent",
+                        currentChatId === chat.id ? "bg-sidebar-accent" : ""
                       )}
                     >
                       <Link prefetch={false} href={`/chat/${chat.id}`}>
@@ -99,24 +100,13 @@ export default function ChatLayout({
             </SidebarMenu>
           </SidebarContent>
           <SidebarFooter className="p-4">
-            {/* <SidebarMenu>
+            <SidebarMenu>
               <SidebarMenuItem>
                 <SidebarMenuButton asChild>
-                  <Button variant="ghost" className="w-full justify-start">
-                    <User className="mr-2 h-4 w-4" />
-                    Profile
-                  </Button>
+                  <ThemeToggle />
                 </SidebarMenuButton>
               </SidebarMenuItem>
-              <SidebarMenuItem>
-                <SidebarMenuButton asChild>
-                  <Button variant="ghost" className="w-full justify-start">
-                    <Settings className="mr-2 h-4 w-4" />
-                    Settings
-                  </Button>
-                </SidebarMenuButton>
-              </SidebarMenuItem>
-            </SidebarMenu> */}
+            </SidebarMenu>
           </SidebarFooter>
         </Sidebar>
         <SidebarInset className="flex flex-1 flex-col overflow-hidden">

--- a/src/app/(app)/render-chat.tsx
+++ b/src/app/(app)/render-chat.tsx
@@ -192,13 +192,13 @@ export function RenderChat({ preloadedChat }: { preloadedChat?: Chat }) {
   }, [selectedModel, chat]);
 
   return (
-    <div className="flex flex-col h-full max-w-full w-full mx-auto bg-white relative">
-      <div className="sticky top-0 z-50 bg-white border-b border-gray-200 safe-area-inset-top">
+    <div className="flex flex-col h-full max-w-full w-full mx-auto bg-background relative">
+      <div className="sticky top-0 z-50 bg-background border-b border-border safe-area-inset-top">
         <div className="flex items-center justify-between px-4 py-3 pt-safe">
           <div className="flex items-center space-x-3">
             <SidebarTrigger />
             <div>
-              <h1 className="font-semibold text-gray-900">
+              <h1 className="font-semibold text-foreground">
                 {chat?.name || preloadedChat?.name || "New Chat"}
               </h1>
             </div>
@@ -254,14 +254,14 @@ export function RenderChat({ preloadedChat }: { preloadedChat?: Chat }) {
               <div
                 className={`md:max-w-[80%] min-w-0 rounded-2xl px-4 py-2 min-h-[36px] break-words ${
                   message?.role === "user"
-                    ? "bg-blue-500 text-white rounded-br-md"
-                    : "bg-gray-100 text-gray-900 rounded-bl-md"
+                    ? "bg-primary text-primary-foreground rounded-br-md"
+                    : "bg-muted text-muted-foreground rounded-bl-md"
                 }`}
               >
                 <Markdown
                   className={clsx(
                     "text-sm",
-                    message?.text?.toString() ? "" : "text-gray-500"
+                    message?.text?.toString() ? "" : "text-muted-foreground"
                   )}
                   components={{
                     code({ className, children }) {
@@ -292,9 +292,9 @@ export function RenderChat({ preloadedChat }: { preloadedChat?: Chat }) {
       </div>
 
       {role === "reader" ? (
-        <div className="sticky bottom-0 z-50 bg-white border-t border-gray-200 px-4 py-3">
+        <div className="sticky bottom-0 z-50 bg-background border-t border-border px-4 py-3">
           <div className="flex items-center justify-between">
-            <span className="text-sm text-gray-500">
+            <span className="text-sm text-muted-foreground">
               You are a reader. You cannot send messages.
             </span>
             <Button
@@ -308,7 +308,7 @@ export function RenderChat({ preloadedChat }: { preloadedChat?: Chat }) {
         </div>
       ) : (
         <div
-          className={`sticky bottom-0 z-50 bg-white border-t border-gray-200 transition-all duration-200 ${
+          className={`sticky bottom-0 z-50 bg-background border-t border-border transition-all duration-200 ${
             isKeyboardVisible ? "pb-2" : ""
           }`}
         >
@@ -324,7 +324,7 @@ export function RenderChat({ preloadedChat }: { preloadedChat?: Chat }) {
                   value={message}
                   autoFocus
                   onChange={(e) => setMessage(e.target.value)}
-                  className="w-full rounded-md border-gray-300 pr-12 py-2 text-base focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                  className="w-full rounded-md border-input pr-12 py-2 text-base focus:ring-2 focus:ring-ring focus:border-transparent bg-background text-foreground"
                   style={{ fontSize: "16px" }}
                 />
               </div>
@@ -341,7 +341,7 @@ export function RenderChat({ preloadedChat }: { preloadedChat?: Chat }) {
               <Button
                 type="submit"
                 size="sm"
-                className="rounded-full w-10 h-10 p-0 bg-blue-500 hover:bg-blue-600 disabled:bg-gray-300"
+                className="rounded-full w-10 h-10 p-0 bg-primary hover:bg-primary/90 disabled:bg-muted"
               >
                 <Send className="h-4 w-4" />
               </Button>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import { Toaster } from "react-hot-toast";
 import { Analytics } from "@vercel/analytics/next";
+import { ThemeProvider } from "@/components/theme-provider";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -29,9 +30,14 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
-        {children}
-        <Toaster />
-        <Analytics />
+        <ThemeProvider
+          defaultTheme="system"
+          storageKey="jazz-ai-chat-theme"
+        >
+          {children}
+          <Toaster />
+          <Analytics />
+        </ThemeProvider>
       </body>
     </html>
   );

--- a/src/components/theme-provider.tsx
+++ b/src/components/theme-provider.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import { createContext, useContext, useEffect, useState } from "react";
+
+type Theme = "dark" | "light" | "system";
+
+type ThemeProviderContext = {
+  theme: Theme;
+  setTheme: (theme: Theme) => void;
+};
+
+const ThemeProviderContext = createContext<ThemeProviderContext | undefined>(
+  undefined
+);
+
+export function ThemeProvider({
+  children,
+  defaultTheme = "system",
+  storageKey = "jazz-ai-chat-theme",
+  ...props
+}: {
+  children: React.ReactNode;
+  defaultTheme?: Theme;
+  storageKey?: string;
+} & React.ComponentProps<"div">) {
+  const [theme, setTheme] = useState<Theme>(() => {
+    if (typeof window !== "undefined") {
+      return (localStorage.getItem(storageKey) as Theme) || defaultTheme;
+    }
+    return defaultTheme;
+  });
+
+  useEffect(() => {
+    const root = window.document.documentElement;
+
+    root.classList.remove("light", "dark");
+
+    if (theme === "system") {
+      const systemTheme = window.matchMedia("(prefers-color-scheme: dark)")
+        .matches
+        ? "dark"
+        : "light";
+
+      root.classList.add(systemTheme);
+      return;
+    }
+
+    root.classList.add(theme);
+  }, [theme]);
+
+  const value = {
+    theme,
+    setTheme: (theme: Theme) => {
+      localStorage.setItem(storageKey, theme);
+      setTheme(theme);
+    },
+  };
+
+  return (
+    <ThemeProviderContext.Provider {...props} value={value}>
+      {children}
+    </ThemeProviderContext.Provider>
+  );
+}
+
+export const useTheme = () => {
+  const context = useContext(ThemeProviderContext);
+
+  if (context === undefined)
+    throw new Error("useTheme must be used within a ThemeProvider");
+
+  return context;
+};

--- a/src/components/ui/theme-toggle.tsx
+++ b/src/components/ui/theme-toggle.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import { Moon, Sun, Monitor } from "lucide-react";
+import { useTheme } from "@/components/theme-provider";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+
+export function ThemeToggle() {
+  const { setTheme } = useTheme();
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button variant="ghost" size="sm" className="w-full justify-start">
+          <Sun className="h-4 w-4 rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
+          <Moon className="absolute h-4 w-4 rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />
+          <span className="ml-2">Theme</span>
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        <DropdownMenuItem onClick={() => setTheme("light")}>
+          <Sun className="mr-2 h-4 w-4" />
+          <span>Light</span>
+        </DropdownMenuItem>
+        <DropdownMenuItem onClick={() => setTheme("dark")}>
+          <Moon className="mr-2 h-4 w-4" />
+          <span>Dark</span>
+        </DropdownMenuItem>
+        <DropdownMenuItem onClick={() => setTheme("system")}>
+          <Monitor className="mr-2 h-4 w-4" />
+          <span>System</span>
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}


### PR DESCRIPTION
Closes #4

Implements comprehensive dark mode support throughout the jazz-ai-chat application.

## Changes
- Add theme provider with localStorage persistence and system preference detection
- Create theme toggle component with light/dark/system options
- Update root layout to include theme provider
- Add theme toggle to sidebar footer for easy access
- Replace hardcoded colors with theme-aware CSS variables throughout the app
- Update chat interface to use proper theme colors
- Fix sidebar colors to use semantic theme variables

## Features
- Light theme
- Dark theme
- System preference detection
- Persistent theme selection
- Smooth theme transitions

Generated with [Claude Code](https://claude.ai/code)